### PR TITLE
Added support for BIRLE4 bitmaps

### DIFF
--- a/src/main/java/com/eyespot/imageparser/bitmap/BitmapConstants.java
+++ b/src/main/java/com/eyespot/imageparser/bitmap/BitmapConstants.java
@@ -143,4 +143,76 @@ public final class BitmapConstants {
 
   /** Offset to the reserved field (usually zero). */
   public static final int BV5_RESERVED_OFFSET = 120;
+
+  // --- Compression Types ---
+  /** No compression (BI_RGB). */
+  public static final int BI_RGB = 0;
+
+  /** RLE 8-bit/pixel compression (BI_RLE8). */
+  public static final int BI_RLE8 = 1;
+
+  /** RLE 4-bit/pixel compression (BI_RLE4). */
+  public static final int BI_RLE4 = 2;
+
+  /** Bitfield compression (BI_BITFIELDS). */
+  public static final int BI_BITFIELDS = 3;
+
+  /** JPEG compression (BI_JPEG). Not supported for direct pixel reading. */
+  public static final int BI_JPEG = 4;
+
+  /** PNG compression (BI_PNG). Not supported for direct pixel reading. */
+  public static final int BI_PNG = 5;
+
+  /** Alpha bitfield compression (BI_ALPHABITFIELDS). */
+  public static final int BI_ALPHABITFIELDS = 6;
+
+  // --- Bit Manipulation Constants ---
+  /** Mask for extracting a single byte (0xFF). */
+  public static final int BYTE_MASK = 0xFF;
+
+  /** Opaque alpha value (fully opaque). */
+  public static final int OPAQUE_ALPHA = 0xFF;
+
+  /** Maximum value for 8-bit colour component. */
+  public static final int MAX_8BIT_VALUE = 255;
+
+  /** Maximum value for 5-bit colour component (used in RGB555). */
+  public static final int RGB5_MAX = 31;
+
+  /** Red channel mask for RGB555 format (5 bits). */
+  public static final int RGB5_RED_MASK = 0x7C00;
+
+  /** Green channel mask for RGB555 format (5 bits). */
+  public static final int RGB5_GREEN_MASK = 0x03E0;
+
+  /** Blue channel mask for RGB555 format (5 bits). */
+  public static final int RGB5_BLUE_MASK = 0x001F;
+
+  /** Default 16-bit RGB565 red mask. */
+  public static final int RGB565_RED_MASK = 0xF800;
+
+  /** Default 16-bit RGB565 green mask. */
+  public static final int RGB565_GREEN_MASK = 0x07E0;
+
+  /** Default 16-bit RGB565 blue mask. */
+  public static final int RGB565_BLUE_MASK = 0x001F;
+
+  /** Default 32-bit red mask (ARGB8888). */
+  public static final long RGB8_RED_MASK = 0x00FF0000L;
+
+  /** Default 32-bit green mask (ARGB8888). */
+  public static final long RGB8_GREEN_MASK = 0x0000FF00L;
+
+  /** Default 32-bit blue mask (ARGB8888). */
+  public static final long RGB8_BLUE_MASK = 0x000000FFL;
+
+  /** Default 32-bit alpha mask (ARGB8888). */
+  public static final long RGB8_ALPHA_MASK = 0xFF000000L;
+
+  // --- Bitfield Mask Data Block Sizes ---
+  /** Size of bitfield mask data for BI_BITFIELDS with 3 masks (12 bytes). */
+  public static final int BITFIELD_MASKS_SIZE_V3 = 12;
+
+  /** Size of bitfield mask data for BI_ALPHABITFIELDS with 4 masks (16 bytes). */
+  public static final int BITFIELD_MASKS_SIZE_V4 = 16;
 }

--- a/src/main/java/com/eyespot/imageparser/bitmap/BitmapParser.java
+++ b/src/main/java/com/eyespot/imageparser/bitmap/BitmapParser.java
@@ -688,6 +688,20 @@ public class BitmapParser implements IParser {
   }
 
   /**
+   * Helper method to check if a pixel is within valid bounds.
+   *
+   * @param x the X coordinate
+   * @param y the Y coordinate
+   * @param row the display row index
+   * @param width the image width
+   * @param displayHeight the image height
+   * @return true if the pixel is within bounds
+   */
+  private boolean isPixelInBounds(int x, int y, int row, int width, int displayHeight) {
+    return x >= 0 && x < width && y >= 0 && y < displayHeight && row >= 0 && row < displayHeight;
+  }
+
+  /**
    * Writes an encoded run to the output pixel array. In encoded mode, a single color index is
    * repeated for the specified run length.
    *
@@ -714,12 +728,7 @@ public class BitmapParser implements IParser {
     int row = displayRowMapOffset + currentY * displayRowMapMultiplier;
 
     for (int i = 0; i < runLength; i++, currentX++) {
-      if (currentX >= 0
-          && currentX < width
-          && currentY >= 0
-          && currentY < displayHeight
-          && row >= 0
-          && row < displayHeight) {
+      if (isPixelInBounds(currentX, currentY, row, width, displayHeight)) {
         pixels[row][currentX] = colour;
       }
     }
@@ -752,12 +761,7 @@ public class BitmapParser implements IParser {
     int row = displayRowMapOffset + (currentY * displayRowMapMultiplier);
 
     for (int i = 0; i < count; i++, currentX++) {
-      if (currentX >= 0
-          && currentX < width
-          && currentY >= 0
-          && currentY < displayHeight
-          && row >= 0
-          && row < displayHeight) {
+      if (isPixelInBounds(currentX, currentY, row, width, displayHeight)) {
         int pixelIndex = data[currentFileOffset + i] & 0xFF;
         pixels[row][currentX] = colourPalette.getColour(pixelIndex);
       }
@@ -871,7 +875,7 @@ public class BitmapParser implements IParser {
     int row = displayRowMapOffset + y * displayRowMapMultiplier;
 
     for (int i = 0; i < runLength; i++) {
-      if (x >= 0 && x < width && y >= 0 && y < displayHeight && row >= 0 && row < displayHeight) {
+      if (isPixelInBounds(x, y, row, width, displayHeight)) {
         int color =
             (i % 2 == 0)
                 ? colourPalette.getColour(colorIndex1)
@@ -898,7 +902,7 @@ public class BitmapParser implements IParser {
     int currentByte = 0;
 
     for (int i = 0; i < numPixels; i++) {
-      if (x >= 0 && x < width && y >= 0 && y < displayHeight && row >= 0 && row < displayHeight) {
+      if (isPixelInBounds(x, y, row, width, displayHeight)) {
         if (i % 2 == 0) {
           currentByte = data[fileOffset + i / 2] & 0xFF;
           int colorIndex = (currentByte >> 4) & 0x0F;

--- a/src/main/java/com/eyespot/imageparser/bitmap/BitmapParser.java
+++ b/src/main/java/com/eyespot/imageparser/bitmap/BitmapParser.java
@@ -851,7 +851,7 @@ public class BitmapParser implements IParser {
             currentFileOffset += (numPixels + 1) / 2;
 
             // Padding to WORD boundary
-            if ((((numPixels + 1) / 2) % 2) != 0) {
+            if ((numPixels + 1) / 2 % 2 != 0) {
               currentFileOffset++;
             }
             break;

--- a/src/main/java/com/eyespot/imageparser/bitmap/BitmapParser.java
+++ b/src/main/java/com/eyespot/imageparser/bitmap/BitmapParser.java
@@ -530,9 +530,7 @@ public class BitmapParser implements IParser {
    * @throws IllegalArgumentException if the DIB header does not specify 8 bits per pixel, or if the
    *     data stream is malformed
    */
-  /**
-   * Helper class to track RLE decoding state and handle common escape sequences.
-   */
+  /** Helper class to track RLE decoding state and handle common escape sequences. */
   private static class RLEDecodingContext {
     int fileOffset;
     int x;
@@ -546,8 +544,11 @@ public class BitmapParser implements IParser {
       this.endOfBitmap = false;
     }
 
-    /** Handles RLE escape sequences that are identical for RLE4 and RLE8. Returns true if handled. */
-    boolean handleEscapeSequence(int code, byte[] data, String format) throws CorruptedImageException {
+    /**
+     * Handles RLE escape sequences that are identical for RLE4 and RLE8. Returns true if handled.
+     */
+    boolean handleEscapeSequence(int code, byte[] data, String format)
+        throws CorruptedImageException {
       final int END_OF_LINE = 0x00;
       final int END_OF_BITMAP = 0x01;
       final int DELTA = 0x02;
@@ -627,7 +628,13 @@ public class BitmapParser implements IParser {
               false);
           ctx.x =
               writeBIRLE8AbsoluteRun(
-                  pixels, code, displayRowMapOffset, displayRowMapMultiplier, ctx.x, ctx.y, ctx.fileOffset);
+                  pixels,
+                  code,
+                  displayRowMapOffset,
+                  displayRowMapMultiplier,
+                  ctx.x,
+                  ctx.y,
+                  ctx.fileOffset);
           ctx.fileOffset += code;
           if (code % 2 != 0) {
             ctx.fileOffset++;
@@ -831,7 +838,13 @@ public class BitmapParser implements IParser {
               false);
           ctx.x =
               writeBIRLE4AbsoluteRun(
-                  pixels, code, displayRowMapOffset, displayRowMapMultiplier, ctx.x, ctx.y, ctx.fileOffset);
+                  pixels,
+                  code,
+                  displayRowMapOffset,
+                  displayRowMapMultiplier,
+                  ctx.x,
+                  ctx.y,
+                  ctx.fileOffset);
           ctx.fileOffset += bytesNeeded;
           if (bytesNeeded % 2 != 0) {
             ctx.fileOffset++;
@@ -1230,15 +1243,15 @@ public class BitmapParser implements IParser {
     }
 
     int[][] pixels = getPixels();
-      for (int[] pixel : pixels) {
-          for (int argb : pixel) {
-              int alpha = (argb >> 24) & BitmapConstants.BYTE_MASK;
-              if (alpha != BitmapConstants.OPAQUE_ALPHA) {
-                  cachedHasAlphaChannel = true;
-                  return true;
-              }
-          }
+    for (int[] pixel : pixels) {
+      for (int argb : pixel) {
+        int alpha = (argb >> 24) & BitmapConstants.BYTE_MASK;
+        if (alpha != BitmapConstants.OPAQUE_ALPHA) {
+          cachedHasAlphaChannel = true;
+          return true;
+        }
       }
+    }
 
     cachedHasAlphaChannel = false;
     return false;

--- a/src/main/java/com/eyespot/imageparser/bitmap/BitmapParser.java
+++ b/src/main/java/com/eyespot/imageparser/bitmap/BitmapParser.java
@@ -532,6 +532,9 @@ public class BitmapParser implements IParser {
    */
   /** Helper class to track RLE decoding state and handle common escape sequences. */
   private static class RLEDecodingContext {
+    private static final int END_OF_LINE = 0x00;
+    private static final int END_OF_BITMAP = 0x01;
+    private static final int DELTA = 0x02;
     int fileOffset;
     int x;
     int y;
@@ -549,10 +552,6 @@ public class BitmapParser implements IParser {
      */
     boolean handleEscapeSequence(int code, byte[] data, String format)
         throws CorruptedImageException {
-      final int END_OF_LINE = 0x00;
-      final int END_OF_BITMAP = 0x01;
-      final int DELTA = 0x02;
-
       switch (code) {
         case END_OF_LINE:
           x = 0;
@@ -1294,7 +1293,9 @@ public class BitmapParser implements IParser {
         throw new UnsupportedOperationException("Unsupported BMP compression type: " + compression);
       }
     } catch (CorruptedImageException e) {
-      LOGGER.log(Level.SEVERE, "Failed to read pixel data: {0}", e.getMessage());
+      if (LOGGER.isLoggable(Level.SEVERE)) {
+        LOGGER.log(Level.SEVERE, "Failed to read pixel data: {0}", e.getMessage());
+      }
     }
 
     return pixels;

--- a/src/main/java/com/eyespot/imageparser/bitmap/ColourPalette.java
+++ b/src/main/java/com/eyespot/imageparser/bitmap/ColourPalette.java
@@ -28,8 +28,7 @@ final class ColourPalette {
     int numEntries;
     // If the number of colours in the colour palette is 0 or colours used > important colours,
     // default to 2^n where n == bits per pixel
-    if (dibHeader.getNColours() == 0
-        || dibHeader.getNColours() > dibHeader.getImportantColours()) {
+    if (dibHeader.getNColours() == 0 || dibHeader.getNColours() > dibHeader.getImportantColours()) {
       numEntries = 1 << dibHeader.getBitsPerPixel(); // Max colours for bit-depth
     } else {
       numEntries = dibHeader.getNColours();

--- a/src/main/java/com/eyespot/imageparser/bitmap/ColourPalette.java
+++ b/src/main/java/com/eyespot/imageparser/bitmap/ColourPalette.java
@@ -1,0 +1,124 @@
+package com.eyespot.imageparser.bitmap;
+
+/**
+ * Represents the colour palette (if present) in a BMP file.
+ *
+ * <p>Only present when bit-depth is ≤ 8. Supports RGBTRIPLE (3-byte) and RGBQUAD (4-byte) palette
+ * entries.
+ *
+ * <p>This class parses and provides access to indexed colour data stored in BMP files. Each palette
+ * entry represents an ARGB colour value.
+ *
+ * @author Kevin Babu
+ * @see <a href="https://en.wikipedia.org/wiki/BMP_file_format#Colour_table">BMP Colour Table</a>
+ */
+final class ColourPalette {
+  private final int[] colours;
+  private final boolean hasAlphaChannel;
+
+  /**
+   * Parses the colour palette from the BMP byte array.
+   *
+   * @param data the image byte array
+   * @param dibHeader the parsed DIB header
+   * @param paletteStartFileOffset file offset where the palette begins
+   * @throws IllegalArgumentException if palette data is truncated or out of bounds
+   */
+  ColourPalette(byte[] data, DIBHeader dibHeader, int paletteStartFileOffset) {
+    int numEntries;
+    // If the number of colours in the colour palette is 0 or colours used > important colours,
+    // default to 2^n where n == bits per pixel
+    if (dibHeader.getNColours() == 0
+        || dibHeader.getNColours() > dibHeader.getImportantColours()) {
+      numEntries = 1 << dibHeader.getBitsPerPixel(); // Max colours for bit-depth
+    } else {
+      numEntries = dibHeader.getNColours();
+    }
+    this.colours = new int[numEntries];
+    int bytesPerPaletteEntry;
+
+    // Determine bytes per palette entry based on DIB header type
+    if (InfoHeaderType.BITMAPCOREHEADER.equals(dibHeader.getType())) {
+      // RGBTRIPLE (no 4th byte for alpha)
+      bytesPerPaletteEntry = 3;
+    } else {
+      // RGBQUAD (has the 4th byte)
+      bytesPerPaletteEntry = 4;
+    }
+
+    boolean foundNonZeroReservedByte = false;
+    boolean explicitAlphaFlag = false;
+
+    // Check for explicit alpha mask in BITMAPV4/V5 headers
+    if (dibHeader instanceof BitmapV4Header) {
+      explicitAlphaFlag = ((BitmapV4Header) dibHeader).getAlphaMask() != 0;
+    }
+
+    for (int i = 0; i < numEntries; i++) {
+      int entryOffset = paletteStartFileOffset + (i * bytesPerPaletteEntry);
+
+      // Basic bounds check for reading from data array
+      if (entryOffset + bytesPerPaletteEntry > data.length) {
+        throw new IllegalArgumentException(
+            String.format(
+                "Palette data truncated or out of bounds at entry %d (offset: %d)",
+                i, entryOffset));
+      }
+
+      // BMP stores BGR order. Alpha is often 0xFF (opaque) or ignored. But will try and handle it
+      // Java lacks unsigned byte hence the need for bitwise operations
+      int blue = data[entryOffset] & BitmapConstants.BYTE_MASK;
+      int green = data[entryOffset + 1] & BitmapConstants.BYTE_MASK;
+      int red = data[entryOffset + 2] & BitmapConstants.BYTE_MASK;
+
+      // Default to opaque
+      int alpha = BitmapConstants.OPAQUE_ALPHA;
+
+      // Check alpha in bytes, if not explicitly stated in header
+      if (bytesPerPaletteEntry == 4) {
+        int parsedAlpha = data[entryOffset + 3] & BitmapConstants.BYTE_MASK;
+        alpha = (parsedAlpha == 0) ? BitmapConstants.OPAQUE_ALPHA : parsedAlpha;
+      }
+
+      foundNonZeroReservedByte = alpha != BitmapConstants.OPAQUE_ALPHA;
+
+      // Store as ARGB (AARRGGBB)
+      this.colours[i] = (alpha << 24) | (red << 16) | (green << 8) | blue;
+    }
+
+    this.hasAlphaChannel = explicitAlphaFlag || foundNonZeroReservedByte;
+  }
+
+  /**
+   * Returns the number of colour entries in the palette.
+   *
+   * @return the number of palette entries
+   */
+  int getNumberOfEntries() {
+    return colours.length;
+  }
+
+  /**
+   * Retrieves a colour entry from the palette.
+   *
+   * @param index the palette index
+   * @return the ARGB colour as {@code 0xAARRGGBB}
+   * @throws IndexOutOfBoundsException if index is out of bounds
+   */
+  int getColour(int index) {
+    if (index < 0 || index >= colours.length) {
+      throw new IndexOutOfBoundsException(
+          String.format("Palette index %d out of bounds [0, %d]", index, colours.length - 1));
+    }
+    return colours[index];
+  }
+
+  /**
+   * Indicates if any alpha channel data is present in the palette.
+   *
+   * @return true if alpha channel is likely present
+   */
+  boolean hasAlphaChannel() {
+    return hasAlphaChannel;
+  }
+}

--- a/src/test/java/com/eyespot/PictureTest.java
+++ b/src/test/java/com/eyespot/PictureTest.java
@@ -171,7 +171,8 @@ class PictureTest {
 
   @Test
   void GivenPicture_WhenCheckAlphaChannel_ThenReturnsCorrectValue() {
-    assertTrue(picture.hasAlpha());
+    // minimal.bmp is a 24bpp RGB image without an alpha channel
+    assertFalse(picture.hasAlpha());
   }
 
   @Test

--- a/src/test/java/com/eyespot/parser/BitmapParserTest.java
+++ b/src/test/java/com/eyespot/parser/BitmapParserTest.java
@@ -1048,25 +1048,66 @@ class BitmapParserTest {
     byte[] bytes =
         new byte[] {
           // File Header (14 bytes)
-          0x42, 0x4D, // "BM" magic number
-          0x3E, 0x00, 0x00, 0x00, // File size: 62 bytes
-          0x00, 0x00, // Reserved1
-          0x00, 0x00, // Reserved2
-          0x00, 0x00, 0x00, 0x00, // Offset: 0 (INVALID - should be 54)
+          0x42,
+          0x4D, // "BM" magic number
+          0x3E,
+          0x00,
+          0x00,
+          0x00, // File size: 62 bytes
+          0x00,
+          0x00, // Reserved1
+          0x00,
+          0x00, // Reserved2
+          0x00,
+          0x00,
+          0x00,
+          0x00, // Offset: 0 (INVALID - should be 54)
           // DIB Header - BITMAPINFOHEADER (40 bytes)
-          0x28, 0x00, 0x00, 0x00, // Header size: 40
-          0x01, 0x00, 0x00, 0x00, // Width: 1
-          0x01, 0x00, 0x00, 0x00, // Height: 1
-          0x01, 0x00, // Color planes: 1
-          0x18, 0x00, // Bits per pixel: 24
-          0x00, 0x00, 0x00, 0x00, // Compression: 0 (BI_RGB)
-          0x04, 0x00, 0x00, 0x00, // Image size: 4 bytes
-          0x13, 0x0B, 0x00, 0x00, // X pixels per meter
-          0x13, 0x0B, 0x00, 0x00, // Y pixels per meter
-          0x00, 0x00, 0x00, 0x00, // Colors used: 0
-          0x00, 0x00, 0x00, 0x00, // Important colors: 0
+          0x28,
+          0x00,
+          0x00,
+          0x00, // Header size: 40
+          0x01,
+          0x00,
+          0x00,
+          0x00, // Width: 1
+          0x01,
+          0x00,
+          0x00,
+          0x00, // Height: 1
+          0x01,
+          0x00, // Color planes: 1
+          0x18,
+          0x00, // Bits per pixel: 24
+          0x00,
+          0x00,
+          0x00,
+          0x00, // Compression: 0 (BI_RGB)
+          0x04,
+          0x00,
+          0x00,
+          0x00, // Image size: 4 bytes
+          0x13,
+          0x0B,
+          0x00,
+          0x00, // X pixels per meter
+          0x13,
+          0x0B,
+          0x00,
+          0x00, // Y pixels per meter
+          0x00,
+          0x00,
+          0x00,
+          0x00, // Colors used: 0
+          0x00,
+          0x00,
+          0x00,
+          0x00, // Important colors: 0
           // Pixel Data (4 bytes: 3 for pixel + 1 padding)
-          (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, 0x00 // White pixel + padding
+          (byte) 0xFF,
+          (byte) 0xFF,
+          (byte) 0xFF,
+          0x00 // White pixel + padding
         };
 
     BitmapParser parser = new BitmapParser(bytes);
@@ -1082,25 +1123,66 @@ class BitmapParserTest {
     byte[] bytes =
         new byte[] {
           // File Header (14 bytes)
-          0x42, 0x4D, // "BM" magic number
-          0x3E, 0x00, 0x00, 0x00, // File size: 62 bytes
-          0x00, 0x00, // Reserved1
-          0x00, 0x00, // Reserved2
-          (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, // Offset: -1 (INVALID)
+          0x42,
+          0x4D, // "BM" magic number
+          0x3E,
+          0x00,
+          0x00,
+          0x00, // File size: 62 bytes
+          0x00,
+          0x00, // Reserved1
+          0x00,
+          0x00, // Reserved2
+          (byte) 0xFF,
+          (byte) 0xFF,
+          (byte) 0xFF,
+          (byte) 0xFF, // Offset: -1 (INVALID)
           // DIB Header - BITMAPINFOHEADER (40 bytes)
-          0x28, 0x00, 0x00, 0x00, // Header size: 40
-          0x01, 0x00, 0x00, 0x00, // Width: 1
-          0x01, 0x00, 0x00, 0x00, // Height: 1
-          0x01, 0x00, // Color planes: 1
-          0x18, 0x00, // Bits per pixel: 24
-          0x00, 0x00, 0x00, 0x00, // Compression: 0 (BI_RGB)
-          0x04, 0x00, 0x00, 0x00, // Image size: 4 bytes
-          0x13, 0x0B, 0x00, 0x00, // X pixels per meter
-          0x13, 0x0B, 0x00, 0x00, // Y pixels per meter
-          0x00, 0x00, 0x00, 0x00, // Colors used: 0
-          0x00, 0x00, 0x00, 0x00, // Important colors: 0
+          0x28,
+          0x00,
+          0x00,
+          0x00, // Header size: 40
+          0x01,
+          0x00,
+          0x00,
+          0x00, // Width: 1
+          0x01,
+          0x00,
+          0x00,
+          0x00, // Height: 1
+          0x01,
+          0x00, // Color planes: 1
+          0x18,
+          0x00, // Bits per pixel: 24
+          0x00,
+          0x00,
+          0x00,
+          0x00, // Compression: 0 (BI_RGB)
+          0x04,
+          0x00,
+          0x00,
+          0x00, // Image size: 4 bytes
+          0x13,
+          0x0B,
+          0x00,
+          0x00, // X pixels per meter
+          0x13,
+          0x0B,
+          0x00,
+          0x00, // Y pixels per meter
+          0x00,
+          0x00,
+          0x00,
+          0x00, // Colors used: 0
+          0x00,
+          0x00,
+          0x00,
+          0x00, // Important colors: 0
           // Pixel Data (4 bytes: 3 for pixel + 1 padding)
-          (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, 0x00 // White pixel + padding
+          (byte) 0xFF,
+          (byte) 0xFF,
+          (byte) 0xFF,
+          0x00 // White pixel + padding
         };
 
     BitmapParser parser = new BitmapParser(bytes);
@@ -1116,26 +1198,67 @@ class BitmapParserTest {
     byte[] bytes =
         new byte[] {
           // File Header (14 bytes)
-          0x42, 0x4D, // "BM" magic number
-          0x46, 0x04, 0x00, 0x00, // File size
-          0x00, 0x00, // Reserved1
-          0x00, 0x00, // Reserved2
-          0x00, 0x00, 0x00, 0x00, // Offset: 0 (INVALID - should be 14+40+1024=1078)
+          0x42,
+          0x4D, // "BM" magic number
+          0x46,
+          0x04,
+          0x00,
+          0x00, // File size
+          0x00,
+          0x00, // Reserved1
+          0x00,
+          0x00, // Reserved2
+          0x00,
+          0x00,
+          0x00,
+          0x00, // Offset: 0 (INVALID - should be 14+40+1024=1078)
           // DIB Header - BITMAPINFOHEADER (40 bytes)
-          0x28, 0x00, 0x00, 0x00, // Header size: 40
-          0x01, 0x00, 0x00, 0x00, // Width: 1
-          0x01, 0x00, 0x00, 0x00, // Height: 1
-          0x01, 0x00, // Color planes: 1
-          0x08, 0x00, // Bits per pixel: 8
-          0x00, 0x00, 0x00, 0x00, // Compression: 0 (BI_RGB)
-          0x04, 0x00, 0x00, 0x00, // Image size: 4 bytes
-          0x13, 0x0B, 0x00, 0x00, // X pixels per meter
-          0x13, 0x0B, 0x00, 0x00, // Y pixels per meter
-          0x00, 0x00, 0x00, 0x00, // Colors used: 0 (defaults to 256)
-          0x00, 0x00, 0x00, 0x00, // Important colors: 0
+          0x28,
+          0x00,
+          0x00,
+          0x00, // Header size: 40
+          0x01,
+          0x00,
+          0x00,
+          0x00, // Width: 1
+          0x01,
+          0x00,
+          0x00,
+          0x00, // Height: 1
+          0x01,
+          0x00, // Color planes: 1
+          0x08,
+          0x00, // Bits per pixel: 8
+          0x00,
+          0x00,
+          0x00,
+          0x00, // Compression: 0 (BI_RGB)
+          0x04,
+          0x00,
+          0x00,
+          0x00, // Image size: 4 bytes
+          0x13,
+          0x0B,
+          0x00,
+          0x00, // X pixels per meter
+          0x13,
+          0x0B,
+          0x00,
+          0x00, // Y pixels per meter
+          0x00,
+          0x00,
+          0x00,
+          0x00, // Colors used: 0 (defaults to 256)
+          0x00,
+          0x00,
+          0x00,
+          0x00, // Important colors: 0
           // Color Palette (256 entries * 4 bytes = 1024 bytes)
           // Entry 0: Black
-          0x00, 0x00, 0x00, 0x00, // B, G, R, Reserved
+          0x00,
+          0x00,
+          0x00,
+          0x00, // B, G, R, Reserved
         };
 
     // Fill remaining 255 palette entries (simplified - all black)

--- a/src/test/java/com/eyespot/parser/BitmapParserTest.java
+++ b/src/test/java/com/eyespot/parser/BitmapParserTest.java
@@ -889,7 +889,7 @@ class BitmapParserTest {
 
   // Compression tests
   @ParameterizedTest
-  @ValueSource(bytes = {2, 4, 5, 6})
+  @ValueSource(bytes = {4, 5, 6})
   void GivenUnsupportedCompression_GetPixels_ThrowsUnsupportedOperationException(byte i) {
     byte[] bytes = Arrays.copyOfRange(commonParser.getRawData(), 0, 55);
     bytes[30] = i;

--- a/src/test/java/com/eyespot/parser/BitmapParserTest.java
+++ b/src/test/java/com/eyespot/parser/BitmapParserTest.java
@@ -45,6 +45,8 @@ class BitmapParserTest {
 
   private static BitmapParser v4ParserWithPaletteAndAlpha;
 
+  private static BitmapParser common4BitCompressedParser;
+
   private static BitmapParser badBitCountParser;
 
   private static BitmapV4Header v4Header;
@@ -100,6 +102,13 @@ class BitmapParserTest {
     Assertions.assertNotNull(common8BitCompressedWithAbsoluteRunParserResource);
     common8BitCompressedWithAbsoluteRunParser =
         new BitmapParser(Paths.get(common8BitCompressedWithAbsoluteRunParserResource.toURI()));
+
+    // Parser for 4bpp BI_RLE4 compressed and has BITMAPINFOHEADER
+    URL common4BitCompressedParserResource =
+        BitmapParserTest.class.getClassLoader().getResource("4bit_compressed.bmp");
+    Assertions.assertNotNull(common4BitCompressedParserResource);
+    common4BitCompressedParser =
+        new BitmapParser(Paths.get(common4BitCompressedParserResource.toURI()));
 
     // Parser for 16bpp bitmap with BITMAPINFOHEADER
     URL commonParser16BitResource =
@@ -529,6 +538,21 @@ class BitmapParserTest {
     Assertions.assertEquals(
         common8BitCompressedWithAbsoluteRunParser.getWidth()
             * common8BitCompressedWithAbsoluteRunParser.getHeight(),
+        totalElements);
+  }
+
+  // 4bpp BI_RLE4 compressed bitmap with BITMAPINFOHEADER
+  @Test
+  void Given4bppCompressedBitmap_GetCompression_Returns2() {
+    Assertions.assertEquals(2, common4BitCompressedParser.getCompression());
+  }
+
+  @Test
+  void Given4BppCompressedBitmap_GetPixels_ReturnAllPixels() {
+    int[][] pixels = common4BitCompressedParser.getPixels();
+    int totalElements = pixels[0].length * pixels.length;
+    Assertions.assertEquals(
+        common4BitCompressedParser.getWidth() * common4BitCompressedParser.getHeight(),
         totalElements);
   }
 

--- a/src/test/java/com/eyespot/parser/BitmapParserTest.java
+++ b/src/test/java/com/eyespot/parser/BitmapParserTest.java
@@ -1040,4 +1040,174 @@ class BitmapParserTest {
     Executable executable = () -> new BitmapParser(Paths.get(paletteResource.toURI()));
     Assertions.assertThrows(IllegalArgumentException.class, executable);
   }
+
+  // Tests for calculateExpectedOffset (zero offset handling)
+  @Test
+  void GivenBitmapWithZeroOffset_WhenGetPixels_ThenUsesCalculatedOffset() {
+    // Create a minimal 1x1 24bpp bitmap with zero offset
+    byte[] bytes =
+        new byte[] {
+          // File Header (14 bytes)
+          0x42, 0x4D, // "BM" magic number
+          0x3E, 0x00, 0x00, 0x00, // File size: 62 bytes
+          0x00, 0x00, // Reserved1
+          0x00, 0x00, // Reserved2
+          0x00, 0x00, 0x00, 0x00, // Offset: 0 (INVALID - should be 54)
+          // DIB Header - BITMAPINFOHEADER (40 bytes)
+          0x28, 0x00, 0x00, 0x00, // Header size: 40
+          0x01, 0x00, 0x00, 0x00, // Width: 1
+          0x01, 0x00, 0x00, 0x00, // Height: 1
+          0x01, 0x00, // Color planes: 1
+          0x18, 0x00, // Bits per pixel: 24
+          0x00, 0x00, 0x00, 0x00, // Compression: 0 (BI_RGB)
+          0x04, 0x00, 0x00, 0x00, // Image size: 4 bytes
+          0x13, 0x0B, 0x00, 0x00, // X pixels per meter
+          0x13, 0x0B, 0x00, 0x00, // Y pixels per meter
+          0x00, 0x00, 0x00, 0x00, // Colors used: 0
+          0x00, 0x00, 0x00, 0x00, // Important colors: 0
+          // Pixel Data (4 bytes: 3 for pixel + 1 padding)
+          (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, 0x00 // White pixel + padding
+        };
+
+    BitmapParser parser = new BitmapParser(bytes);
+    Assertions.assertDoesNotThrow(parser::getPixels);
+    int[][] pixels = parser.getPixels();
+    Assertions.assertEquals(1, pixels.length);
+    Assertions.assertEquals(1, pixels[0].length);
+  }
+
+  @Test
+  void GivenBitmapWithNegativeOffset_WhenGetPixels_ThenUsesCalculatedOffset() {
+    // Create a minimal 1x1 24bpp bitmap with negative offset
+    byte[] bytes =
+        new byte[] {
+          // File Header (14 bytes)
+          0x42, 0x4D, // "BM" magic number
+          0x3E, 0x00, 0x00, 0x00, // File size: 62 bytes
+          0x00, 0x00, // Reserved1
+          0x00, 0x00, // Reserved2
+          (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, // Offset: -1 (INVALID)
+          // DIB Header - BITMAPINFOHEADER (40 bytes)
+          0x28, 0x00, 0x00, 0x00, // Header size: 40
+          0x01, 0x00, 0x00, 0x00, // Width: 1
+          0x01, 0x00, 0x00, 0x00, // Height: 1
+          0x01, 0x00, // Color planes: 1
+          0x18, 0x00, // Bits per pixel: 24
+          0x00, 0x00, 0x00, 0x00, // Compression: 0 (BI_RGB)
+          0x04, 0x00, 0x00, 0x00, // Image size: 4 bytes
+          0x13, 0x0B, 0x00, 0x00, // X pixels per meter
+          0x13, 0x0B, 0x00, 0x00, // Y pixels per meter
+          0x00, 0x00, 0x00, 0x00, // Colors used: 0
+          0x00, 0x00, 0x00, 0x00, // Important colors: 0
+          // Pixel Data (4 bytes: 3 for pixel + 1 padding)
+          (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, 0x00 // White pixel + padding
+        };
+
+    BitmapParser parser = new BitmapParser(bytes);
+    Assertions.assertDoesNotThrow(parser::getPixels);
+    int[][] pixels = parser.getPixels();
+    Assertions.assertEquals(1, pixels.length);
+    Assertions.assertEquals(1, pixels[0].length);
+  }
+
+  @Test
+  void GivenBitmapWithZeroOffsetAndPalette_WhenGetPixels_ThenCalculatesOffsetWithPalette() {
+    // Create a minimal 1x1 8bpp bitmap with zero offset and color palette
+    byte[] bytes =
+        new byte[] {
+          // File Header (14 bytes)
+          0x42, 0x4D, // "BM" magic number
+          0x46, 0x04, 0x00, 0x00, // File size
+          0x00, 0x00, // Reserved1
+          0x00, 0x00, // Reserved2
+          0x00, 0x00, 0x00, 0x00, // Offset: 0 (INVALID - should be 14+40+1024=1078)
+          // DIB Header - BITMAPINFOHEADER (40 bytes)
+          0x28, 0x00, 0x00, 0x00, // Header size: 40
+          0x01, 0x00, 0x00, 0x00, // Width: 1
+          0x01, 0x00, 0x00, 0x00, // Height: 1
+          0x01, 0x00, // Color planes: 1
+          0x08, 0x00, // Bits per pixel: 8
+          0x00, 0x00, 0x00, 0x00, // Compression: 0 (BI_RGB)
+          0x04, 0x00, 0x00, 0x00, // Image size: 4 bytes
+          0x13, 0x0B, 0x00, 0x00, // X pixels per meter
+          0x13, 0x0B, 0x00, 0x00, // Y pixels per meter
+          0x00, 0x00, 0x00, 0x00, // Colors used: 0 (defaults to 256)
+          0x00, 0x00, 0x00, 0x00, // Important colors: 0
+          // Color Palette (256 entries * 4 bytes = 1024 bytes)
+          // Entry 0: Black
+          0x00, 0x00, 0x00, 0x00, // B, G, R, Reserved
+        };
+
+    // Fill remaining 255 palette entries (simplified - all black)
+    byte[] fullBytes = new byte[14 + 40 + 1024 + 4];
+    System.arraycopy(bytes, 0, fullBytes, 0, bytes.length);
+    // Add pixel data at the end
+    fullBytes[fullBytes.length - 4] = 0x00; // Pixel index 0
+    fullBytes[fullBytes.length - 3] = 0x00; // Padding
+    fullBytes[fullBytes.length - 2] = 0x00; // Padding
+    fullBytes[fullBytes.length - 1] = 0x00; // Padding
+
+    BitmapParser parser = new BitmapParser(fullBytes);
+    Assertions.assertDoesNotThrow(parser::getPixels);
+    int[][] pixels = parser.getPixels();
+    Assertions.assertEquals(1, pixels.length);
+    Assertions.assertEquals(1, pixels[0].length);
+  }
+
+  // Tests for hasAlphaChannel optimization and caching
+  @Test
+  void GivenBitmap_WhenHasAlphaChannelCalledTwice_ThenReturnsCachedResult() {
+    // First call should compute the result
+    boolean firstCall = v4ParserWithPaletteAndAlpha.hasAlphaChannel();
+    // Second call should return cached result (faster)
+    boolean secondCall = v4ParserWithPaletteAndAlpha.hasAlphaChannel();
+
+    Assertions.assertEquals(firstCall, secondCall);
+    Assertions.assertTrue(firstCall); // This bitmap is known to have alpha
+  }
+
+  @Test
+  void GivenV3BitmapWithAlphaMask_WhenHasAlphaChannel_ThenReturnsTrueWithoutPixelScan() {
+    // v3Parser is already initialized and has an alpha mask
+    // This test verifies that hasAlphaChannel returns true based on header metadata
+    boolean hasAlpha = v3Parser.hasAlphaChannel();
+    Assertions.assertTrue(hasAlpha);
+
+    // Verify it can be called multiple times (caching)
+    boolean hasAlphaCached = v3Parser.hasAlphaChannel();
+    Assertions.assertTrue(hasAlphaCached);
+  }
+
+  @Test
+  void GivenV4BitmapWithAlphaMask_WhenHasAlphaChannel_ThenReturnsTrueWithoutPixelScan() {
+    // v4Parser is already initialized and has an alpha mask
+    boolean hasAlpha = v4Parser.hasAlphaChannel();
+    Assertions.assertTrue(hasAlpha);
+
+    // Verify it can be called multiple times (caching)
+    boolean hasAlphaCached = v4Parser.hasAlphaChannel();
+    Assertions.assertTrue(hasAlphaCached);
+  }
+
+  @Test
+  void GivenCommonBitmapWithoutAlpha_WhenHasAlphaChannel_ThenReturnsFalse() {
+    // commonParser is a 24bpp image without alpha
+    boolean hasAlpha = commonParser.hasAlphaChannel();
+    Assertions.assertFalse(hasAlpha);
+
+    // Verify caching works
+    boolean hasAlphaCached = commonParser.hasAlphaChannel();
+    Assertions.assertFalse(hasAlphaCached);
+  }
+
+  @Test
+  void GivenBitmapWithPalette_WhenHasAlphaChannel_ThenChecksPaletteFirst() {
+    // commonParserWithColourPalette has a palette but no alpha
+    boolean hasAlpha = commonParserWithColourPalette.hasAlphaChannel();
+    Assertions.assertFalse(hasAlpha);
+
+    // v4ParserWithPaletteAndAlpha has a palette with alpha
+    boolean hasAlphaWithPalette = v4ParserWithPaletteAndAlpha.hasAlphaChannel();
+    Assertions.assertTrue(hasAlphaWithPalette);
+  }
 }


### PR DESCRIPTION
## Description

- Add support for 4bpp images with BI_RLE4 compression.
- Handle images that have the offset set to zero
- Fix get alpha channel and cache results

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist

- [x] I have tested the code and verified it works as expected
- [x] I have added or updated tests as needed
- [x] I have added relevant documentation/comments
- [ ] I have linked to the related issue (if applicable)

## Screenshots (if applicable)

## Additional Notes
